### PR TITLE
Bug fixes + friendlier output + use full IDs.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -54,7 +54,7 @@ var cal = norcal({
 if (argv._[0] === 'add') {
   var value = { title: argv.title }
   var opts = { created: argv.created, value: value }
-  cal.add(argv._.join(' '), opts, function (err) {
+  cal.add(argv._.splice(1).join(' '), opts, function (err) {
     if (err) exit(err)
   })
 } else if (argv._[0] === 'query') {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -54,7 +54,11 @@ var cal = norcal({
 if (argv._[0] === 'add') {
   var value = { title: argv.title }
   var opts = { created: argv.created, value: value }
-  cal.add(argv._.splice(1).join(' '), opts, function (err) {
+  cal.add(argv._.splice(1).join(' '), opts, function (err, node) {
+    if (!err && node) {
+      var title = node.value.v.value.title
+      console.error('[' + node.value.k + '] Added "' + title + '": ' + node.value.v.time + '.')
+    }
     if (err) exit(err)
   })
 } else if (argv._[0] === 'query') {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -98,7 +98,7 @@ if (argv._[0] === 'add') {
     var caltxt = calmonth(new Date, { colors: colors })
     var evlines = keys.map(function (key) {
       var c = 'bright ' + xcolors[indexes[key]%xcolors.length]
-      return fcolor(c) + '[' + indexes[key] + '] '
+      return fcolor(c) + '[' + key + '] '
         + times[key] + reset + ' ' + titles[key]
     })
     console.log(layers([

--- a/index.js
+++ b/index.js
@@ -43,7 +43,13 @@ Cal.prototype.add = function (time, opts, cb) {
 }
 
 Cal.prototype.remove = function (id, cb) {
-  this.kv.del(id, cb)
+  var kv = this.kv
+  kv.get(id, function (err, entry) {
+    if (Object.keys(entry).length === 0) {
+      return cb(new Error('No such event.'))
+    }
+    kv.del(id, cb)
+  })
 }
 
 Cal.prototype.query = function (opts, cb) {


### PR DESCRIPTION
## changes

- `norcal add "every tuesday"` would take ALL params, and thus use the time
string "add every tuesday".
- `norcal rm foo` would always succeed, even if no locally known event `foo`
exists.
- `norcal add "oct 11 at 5pm" -t meditation` now outputs `[fce1baef6db7db9b]
Added "meditation": oct 11 at 5pm.`
- `norcal rm` informs you when the event does not exist, but is still silent on
success.

## use full IDs

There was discussion in https://github.com/substack/norcal/pull/3 about this, so this change is more controversial. I argue for full IDs in all UIs because short IDs are view-local, which I contend is inherently confusing in CLI programs. I think this is because I can't look at *any* norcal output and know how to access/modify/delete the events it references. What if I was looking at another month and wanted to reference the event in another context?

I think git does a good job at what it does, and I think that's in part because identifiers are consistent *everywhere*.