### PR TITLE
Make opts optional on add

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,13 @@ function Cal (opts) {
 }
 
 Cal.prototype.add = function (time, opts, cb) {
+  if (opts && !cb) {
+    cb = opts
+    opts = null
+  }
+  opts = opts || {}
+  opts.created = opts.created || new Date
+
   var id = randombytes(8).toString('hex')
   this.kv.put(id, xtend(opts, { time: time }), function (err, node) {
     if (cb) cb(err, node, id)


### PR DESCRIPTION
The README lists `opts.created` on `add()` as optional, but the module will crash if it's not provided. This sets a sane default and also handles the case where `opts` is not provided at all.

This also includes a bit of a clean-up on the CLI to include reverse highlighting on today's events.